### PR TITLE
Fix Dockerfile psych gem installation and security warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Dockerfile for custom Redmica build (with RAG tools and LDAP patch)
 FROM ruby:3.2-slim
 
-# Install system dependencies
+# Install system dependencies including libyaml-dev for psych gem
 RUN apt-get update -qq && \
-    apt-get install -y build-essential libpq-dev nodejs npm imagemagick git curl && \
+    apt-get install -y build-essential libpq-dev nodejs npm imagemagick git curl \
+                       libyaml-dev libffi-dev libssl-dev && \
     npm install -g yarn && \
     rm -rf /var/lib/apt/lists/*
 
@@ -20,14 +21,10 @@ COPY . .
 
 # Set environment variables for asset compilation
 ENV RAILS_ENV=production \
-    DATABASE_URL=postgresql://dummy:dummy@dummy:5432/dummy \
-    SECRET_KEY_BASE=dummy_key_for_build_only
+    DATABASE_URL=postgresql://dummy:dummy@dummy:5432/dummy
 
-# Precompile assets
-RUN bundle exec rake assets:precompile
-
-# Remove the dummy secret key after asset compilation
-ENV SECRET_KEY_BASE=
+# Precompile assets with temporary secret key
+RUN SECRET_KEY_BASE=dummy_key_for_build_only bundle exec rake assets:precompile
 
 # Create non-root user
 RUN useradd -m -u 1000 redmica && \


### PR DESCRIPTION
## Problem
Docker build was failing with:
- `psych` gem installation error (exit code 5)
- Security warnings about SECRET_KEY_BASE in ENV/ARG

## Solution
- **Added system dependencies**: `libyaml-dev`, `libffi-dev`, `libssl-dev` for psych gem compilation
- **Fixed security warnings**: Use RUN-time SECRET_KEY_BASE instead of ENV variables
- **Cleaner build process**: Temporary secret key only during asset precompilation

## Changes
- Added required system packages for psych gem native compilation
- Replaced ENV SECRET_KEY_BASE with RUN-time variable assignment
- Eliminated Docker security scanner warnings

## Testing
This should resolve the bundle install failures and allow successful container builds for Release.com deployment.